### PR TITLE
freeze torch version before weights.only=true 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 soundfile
 scipy
-torch>=1.8.1
+torch<2.6
 tqdm
 librosa
 demucs


### PR DESCRIPTION
freeze torch version before the weights_only=True argument in the torch.load function was added, preventing the model from running. 